### PR TITLE
Missions events

### DIFF
--- a/src/Pages/mission/events.js
+++ b/src/Pages/mission/events.js
@@ -1,0 +1,11 @@
+export const buttonClass = (joined) => {
+  let classes = 'btn';
+  classes += joined ? 'red' : 'dark';
+  return classes;
+};
+
+export const badgeClass = (joined) => {
+  let classes = 'badge bg-';
+  classes += joined ? 'blue' : 'dark';
+  return classes;
+};

--- a/src/Pages/mission/missions_body.js
+++ b/src/Pages/mission/missions_body.js
@@ -1,6 +1,8 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
+import { buttonClass, badgeClass } from './events';
+
 import {
   FetchMissions, leaveMission, joinMission,
 } from '../../Redux/Missions/Missions';
@@ -15,26 +17,20 @@ const MissionsBody = () => {
     dispatch(FetchMissions());
   }, [dispatch]);
 
-  const handleJoin = (e) => { // actually not working, will be updated in next task
-    // Check if the button text is Join Mission or Leave Mission
-    if (e.target.textContent === 'Join Mission') {
-      dispatch(joinMission(e.target.id));
-    } else {
+  const handleJoin = (e) => {
+    if (e.target.textContent === 'Leave mission') {
       dispatch(leaveMission(e.target.id));
+    } else {
+      dispatch(joinMission(e.target.id));
     }
-  };
-
-  const changeBackgroundColor = (joined) => { // actually not working, will be updated in next task
-    let classes = 'btn';
-    classes += joined ? 'red' : 'black';
-    return classes;
   };
 
   return (
     <tbody>
       {missions.map((mission) => {
         // actually not working, will be updated in next task
-        const changeButtonClass = changeBackgroundColor(mission.joined);
+        const changeButtonClass = buttonClass(mission.joined);
+        const changeBadgeClass = badgeClass(mission.joined);
         // change the text of the button depending on the member status and action
         let Status;
         let Action;
@@ -50,7 +46,7 @@ const MissionsBody = () => {
             <td>{mission.mission_name}</td>
             <td>{mission.description}</td>
             <td>
-              <span>{Status}</span>
+              <span className={changeBadgeClass}>{Status}</span>
             </td>
             <td>
               <button id={mission.mission_id} type="button" className={changeButtonClass} onClick={handleJoin}>{Action}</button>

--- a/src/Redux/ConfigureStore.js
+++ b/src/Redux/ConfigureStore.js
@@ -6,7 +6,7 @@ const store = configureStore({
   reducer: {
     rockets: rocketsSlice,
     missions: MissionsReducer,
-},
+  },
 });
 
 export default store;


### PR DESCRIPTION
In this PR, we are adding events on missions page

- Missions that the user has joined already should show a badge "Active Member" instead of the default "NOT A MEMBER" and a button "Leave Mission" instead of the "Join Mission" button (as per design).
Happy review!